### PR TITLE
fix: disconnect from device on stopPolling

### DIFF
--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Bluetooth/Bluetooth.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Bluetooth/Bluetooth.cs
@@ -127,6 +127,7 @@ namespace FindMyBLEDevice.Services.Bluetooth
                         {
                             Console.WriteLine(e.ToString());
                         }
+                        await adapter.DisconnectDeviceAsync(device);
                         if (!(disconnected is null)) disconnected.Invoke();
                     }
                     catch (Exception e)


### PR DESCRIPTION
While working on the issue of deleting a device, I noticed that after the deletion, the device could not be found on the next scan although it was not in the filter of the saved devices anymore.
After some checking I noticed that if you disconnect from the device, it works.

Since this is a rather general change I wanted to keep it in an own PR.


Signed-off-by: Dominik Pysch <domi.pysch@gmail.com>