### PR TITLE
fix map page bugs and a performance improvement

### DIFF
--- a/Implementation/FindMyBLEDevice.Tests/ViewModelTests/ItemViewModelTests.cs
+++ b/Implementation/FindMyBLEDevice.Tests/ViewModelTests/ItemViewModelTests.cs
@@ -31,16 +31,16 @@ namespace FindMyBLEDevice.Tests.ViewModelTests
             // act
             vm.OnAppearing();
             var firstState = vm.SavedDevices;
-            ds.Raise(mock => mock.DevicesChanged += null, EventArgs.Empty);
+            ds.Raise(mock => mock.DevicesChanged += null, null, It.IsAny<List<int>>());
             var secondState = vm.SavedDevices;
-            ds.Raise(mock => mock.DevicesChanged += null, EventArgs.Empty);
+            ds.Raise(mock => mock.DevicesChanged += null, null, It.IsAny<List<int>>());
             var thirdState = vm.SavedDevices;
             vm.OnDisappearing();
 
             // assert
             ds.Verify(mock => mock.GetAllDevices(), Times.Exactly(3));
-            ds.VerifyAdd(mock => mock.DevicesChanged += It.IsAny<EventHandler>(), Times.Once);
-            ds.VerifyRemove(mock => mock.DevicesChanged -= It.IsAny<EventHandler>(), Times.Once);
+            ds.VerifyAdd(mock => mock.DevicesChanged += It.IsAny<EventHandler<List<int>>>(), Times.Once);
+            ds.VerifyRemove(mock => mock.DevicesChanged -= It.IsAny<EventHandler<List<int>>>(), Times.Once);
             Assert.AreEqual(1, firstState.Count);
             Assert.AreEqual(2, secondState.Count);
             Assert.AreEqual(1, thirdState.Count);

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Database/DevicesStore.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Database/DevicesStore.cs
@@ -119,6 +119,7 @@ namespace FindMyBLEDevice.Services.Database
 
         public void AtomicGetAndUpdateDevice(BTDevice device, Action<BTDevice> manipulation)
         {
+            if (device is null) return;
             lock(_database)
             {
                 var getTask = GetDevice(device.ID);

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Database/DevicesStore.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Database/DevicesStore.cs
@@ -21,7 +21,7 @@ namespace FindMyBLEDevice.Services.Database
          */
         private readonly SQLiteAsyncConnection _database;
 
-        public event EventHandler DevicesChanged;
+        public event EventHandler<List<int>> DevicesChanged;
 
         public BTDevice SelectedDevice { get; set; }
 
@@ -48,7 +48,7 @@ namespace FindMyBLEDevice.Services.Database
                 throw new DeviceStoreException("Saving device failed!");
             }
 
-            DevicesChanged?.Invoke(this, EventArgs.Empty);
+            DevicesChanged?.Invoke(this, new List<int>() { device.ID });
 
             return await GetDeviceByGUID(device.BT_GUID);
         }
@@ -64,7 +64,7 @@ namespace FindMyBLEDevice.Services.Database
                 throw new DeviceStoreException("Updating device failed!");
             }
 
-            DevicesChanged?.Invoke(this, EventArgs.Empty);
+            DevicesChanged?.Invoke(this, new List<int>() { device.ID });
 
         }
 
@@ -79,7 +79,7 @@ namespace FindMyBLEDevice.Services.Database
                 throw new DeviceStoreException("Deleting device failed!");
             }
 
-            DevicesChanged?.Invoke(this, EventArgs.Empty);
+            DevicesChanged?.Invoke(this, new List<int>() { id });
 
         }
 

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Database/IDevicesStore.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Database/IDevicesStore.cs
@@ -96,6 +96,6 @@ namespace FindMyBLEDevice.Services.Database
         /// <param name="manipulation">A method that applies the manipulations to the device object.</param>
         void AtomicGetAndUpdateDevice(BTDevice device, Action<BTDevice> manipulation);
 
-        event EventHandler DevicesChanged;
+        event EventHandler<List<int>> DevicesChanged;
     }
 }

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Geolocation/Geolocation.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/Geolocation/Geolocation.cs
@@ -4,8 +4,6 @@
 // SPDX-FileCopyrightText: 2022 Adrian Wandinger <adrian.wandinger@fau.de>
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Essentials;
@@ -37,11 +35,10 @@ namespace FindMyBLEDevice.Services.Geolocation
             catch (PermissionException)
             {
                 Console.WriteLine("No permission");
-                // Handle permission exception
             }
             catch (Exception)
             {
-                // Unable to get location
+                Console.WriteLine("Getting location failed");
             }
             return null;
         }

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/UpdateService.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/UpdateService.cs
@@ -39,7 +39,7 @@ namespace FindMyBLEDevice.Services
             running = false;
         }
 
-        private async void OnSavedDevicesStoreChanged(object sender, EventArgs e)
+        private async void OnSavedDevicesStoreChanged(object sender, List<int> ids)
         {
             savedDevices = await devicesStore.GetAllDevices();
         }

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/UpdateService.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/UpdateService.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2022 Leo Köberlein <leo@wolfgang-koeberlein.de>
 // SPDX-FileCopyrightText: 2022 Adrian Wandinger<adrian.wandinger@fau.de>
 
+using FindMyBLEDevice.Exceptions;
 using FindMyBLEDevice.Models;
 using FindMyBLEDevice.Services.Bluetooth;
 using FindMyBLEDevice.Services.Database;
@@ -124,7 +125,13 @@ namespace FindMyBLEDevice.Services
                         dev.WithinRange = true;
                     };
                 }
-                devicesStore.AtomicGetAndUpdateDevice(databaseDevice, manipulation);
+                try
+                {
+                    devicesStore.AtomicGetAndUpdateDevice(databaseDevice, manipulation);
+                } catch (DeviceStoreException e)
+                {
+                    Console.WriteLine($"Failed to update a device");
+                }
             }
         }
     }

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/UpdateService.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Services/UpdateService.cs
@@ -128,7 +128,7 @@ namespace FindMyBLEDevice.Services
                 try
                 {
                     devicesStore.AtomicGetAndUpdateDevice(databaseDevice, manipulation);
-                } catch (DeviceStoreException e)
+                } catch (DeviceStoreException)
                 {
                     Console.WriteLine($"Failed to update a device");
                 }

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/ItemDetailViewModel.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/ItemDetailViewModel.cs
@@ -107,8 +107,15 @@ namespace FindMyBLEDevice.ViewModels
                 return;
             }
 
-            await devicesStore.DeleteDevice(Device.ID);
+            var id = Device.ID;
             devicesStore.SelectedDevice = null;
+            try
+            {
+                await devicesStore.DeleteDevice(id);
+            } catch (Exception e)
+            {
+                Console.WriteLine($"[DevicesView] Deleting device failed: {e.StackTrace}");
+            }
 
             // Go back to devices page
             await navigator.GoToAsync("..");

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/ItemsViewModel.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/ItemsViewModel.cs
@@ -15,6 +15,7 @@ using FindMyBLEDevice.Services.Bluetooth;
 using FindMyBLEDevice.Services.Location;
 using System.Threading;
 using FindMyBLEDevice.Services;
+using System.Collections.Generic;
 
 namespace FindMyBLEDevice.ViewModels
 {
@@ -83,7 +84,7 @@ namespace FindMyBLEDevice.ViewModels
             await navigator.GoToAsync(page, newStack);
         }
 
-        private async void OnDevicesChanged(object sender, EventArgs e)
+        private async void OnDevicesChanged(object sender, List<int> ids)
         {
             try
             {

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/MapViewModel.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/MapViewModel.cs
@@ -13,6 +13,7 @@ using FindMyBLEDevice.Services.Database;
 using FindMyBLEDevice.Services.Geolocation;
 using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
 
 namespace FindMyBLEDevice.ViewModels
 {
@@ -87,7 +88,7 @@ namespace FindMyBLEDevice.ViewModels
             map.Pins.Add(devicePin);
         }
 
-        private async void CheckIfSelectedDeviceReachable(object sender, EventArgs ea)
+        private async void CheckIfSelectedDeviceReachable(object sender, List<int> ids)
         {
             if (showingDialogue || Device is null) return;
             showingDialogue = true;

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/MapViewModel.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/MapViewModel.cs
@@ -14,6 +14,7 @@ using FindMyBLEDevice.Services.Geolocation;
 using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
+using FindMyBLEDevice.Views;
 
 namespace FindMyBLEDevice.ViewModels
 {
@@ -90,7 +91,7 @@ namespace FindMyBLEDevice.ViewModels
 
         private async void CheckIfSelectedDeviceReachable(object sender, List<int> ids)
         {
-            if (showingDialogue || Device is null) return;
+            if (showingDialogue || Device is null || !ids.Contains(Device.ID)) return;
             showingDialogue = true;
 
             BTDevice updatedDevice = null;
@@ -108,6 +109,12 @@ namespace FindMyBLEDevice.ViewModels
                 devicesStore.DevicesChanged -= CheckIfSelectedDeviceReachable;
                 bool promptAnswer = false;
                 await Xamarin.Forms.Device.InvokeOnMainThreadAsync(async () => {
+                    // the database operation and switching threads can take a while,
+                    // so make sure the map page is still displayed
+                    bool stillShowing =
+                        Application.Current.MainPage is MapPage
+                        || (Application.Current.MainPage is AppShell shell && shell.CurrentPage is MapPage);
+                    if (!stillShowing) return;
                     promptAnswer = await Application.Current.MainPage.DisplayAlert($"BLE Signal From {Device.UserLabel} Detected", $"Do you want to switch to the signal strength search?", "Yes", "No");
                 });
                 if (promptAnswer)

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/MapViewModel.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/MapViewModel.cs
@@ -60,7 +60,6 @@ namespace FindMyBLEDevice.ViewModels
                 async () => await OpenMapswithPin());
 
             PropertyChanged += DeviceChanged;
-            devicesStore.DevicesChanged += UpdateDisplayedDevice;
         }
 
         private void DeviceChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -176,10 +175,12 @@ namespace FindMyBLEDevice.ViewModels
             devicesStore.DevicesChanged += CheckIfSelectedDeviceReachable;
 
             DisplayDevicePin(Device);
+            devicesStore.DevicesChanged += UpdateDisplayedDevice;
         }
 
         public void OnDisappearing() {
             devicesStore.DevicesChanged -= CheckIfSelectedDeviceReachable;
+            devicesStore.DevicesChanged -= UpdateDisplayedDevice;
         }
     }
 }

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/NewItemViewModel.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/ViewModels/NewItemViewModel.cs
@@ -3,6 +3,7 @@
 
 using FindMyBLEDevice.Models;
 using FindMyBLEDevice.Services.Database;
+using FindMyBLEDevice.Services.Geolocation;
 using System;
 using Xamarin.Forms;
 
@@ -12,6 +13,7 @@ namespace FindMyBLEDevice.ViewModels
     {
         private readonly INavigator navigator;
         private readonly IDevicesStore devicesStore;
+        private readonly IGeolocation geolocation;
 
         public Command SaveCommand { get; }
         public Command CancelCommand { get; }
@@ -25,10 +27,11 @@ namespace FindMyBLEDevice.ViewModels
             set => SetProperty(ref _userLabel, value);
         }
 
-        public NewItemViewModel(INavigator navigator, IDevicesStore devicesStore)
+        public NewItemViewModel(INavigator navigator, IDevicesStore devicesStore, IGeolocation geolocation)
         {
             this.navigator = navigator;
             this.devicesStore = devicesStore;
+            this.geolocation = geolocation;
 
             SaveCommand = new Command(OnSave);
             CancelCommand = new Command(OnCancel);
@@ -50,6 +53,11 @@ namespace FindMyBLEDevice.ViewModels
             {
                 Device.UserLabel = UserLabel;
             }
+
+            var location = await geolocation.GetCurrentLocation();
+            Device.LastGPSLongitude = location.Longitude;
+            Device.LastGPSLatitude = location.Latitude;
+            Device.LastGPSTimestamp = DateTime.Now;
 
             devicesStore.SelectedDevice = await devicesStore.AddDevice(Device);
 

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Views/MapPage.xaml.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Views/MapPage.xaml.cs
@@ -26,5 +26,11 @@ namespace FindMyBLEDevice.Views
             base.OnAppearing();
             viewModel.OnAppearing();
         }
+
+        protected override void OnDisappearing()
+        {
+            base.OnDisappearing();
+            viewModel.OnDisappearing();
+        }
     }
 }

--- a/Implementation/FindMyBLEDevice/FindMyBLEDevice/Views/NewItemPage.xaml.cs
+++ b/Implementation/FindMyBLEDevice/FindMyBLEDevice/Views/NewItemPage.xaml.cs
@@ -14,7 +14,7 @@ namespace FindMyBLEDevice.Views
         {
             InitializeComponent();
 
-            BindingContext = _viewModel = new NewItemViewModel(App.Navigator, App.DevicesStore);
+            BindingContext = _viewModel = new NewItemViewModel(App.Navigator, App.DevicesStore, App.Geolocation);
         }
 
         protected override void OnAppearing()


### PR DESCRIPTION
This PR contains the following changes:
- bugfix #259 
- bugfix #258 
- DevicesChanged event passes a list of IDs of the changed devices to its handlers. This enables the viewmodels to only query the database when really necessary.